### PR TITLE
Fix: create the Vue components shared directory recursively + make the app.blade.php Laravel >= 5.7 compliant

### DIFF
--- a/src/Preset.php
+++ b/src/Preset.php
@@ -77,7 +77,7 @@ class Preset extends LaravelPreset
         copy(__DIR__ . '/stubs/js/app.js', resource_path('js/app.js'));
 
         if (!File::isDirectory(resource_path('js/components/shared'))) {
-            File::makeDirectory(resource_path('js/components/shared'));
+            File::makeDirectory(resource_path('js/components/shared'), 0755, true);
         } else {
             File::cleanDirectory(resource_path('js/components/shared'));
         }

--- a/src/stubs/views/layouts/app.blade.php
+++ b/src/stubs/views/layouts/app.blade.php
@@ -10,7 +10,7 @@
     <!-- Custom Meta Tags -->
     @yield('meta-tags')
 
-    <title>{{ title_case(env('APP_NAME', 'Laravel')) }}</title>
+    <title>{{ class_exists('Str') ? Str::title(env('APP_NAME', 'Laravel')) : title_case(env('APP_NAME', 'Laravel')) }}</title>
 
     <!-- Fonts & Icons -->
     <link rel="dns-prefetch" href="https://fonts.gstatic.com">
@@ -27,7 +27,7 @@
         @yield('content')
     </main>
 
-    <div id="env-indicator" class="{{ kebab_case(env('APP_ENV')) }}"></div>
+    <div id="env-indicator" class="{{ class_exists('Str') ? Str::kebab(env('APP_ENV')) : kebab_case(env('APP_ENV')) }}"></div>
 </div>
 
 <!-- Scripts -->


### PR DESCRIPTION
It didn't work on a fresh Laravel install when no UI preset has been already initialized.

Signed-off-by: Eric Villard <dev@eviweb.fr>